### PR TITLE
Google Admob SDK doesn't support Universal Windows Platform

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,8 +8,7 @@
       "android",
       "ios",
       "amazon-fireos",
-      "wp8",
-      "windows"
+      "wp8"
     ]
   },
   "repository": {

--- a/plugin.xml
+++ b/plugin.xml
@@ -125,6 +125,7 @@
      </platform>
 
      <!-- Windows Phone 8.1+ -->
+     <!-- 
      <platform name="windows">
          <config-file target="Properties/WMAppManifest.xml" parent="/Deployment/App/Capabilities">
              <Capability Name="ID_CAP_LOCATION" />
@@ -139,5 +140,5 @@
           
         <framework src="src/wp8/GoogleAds.dll" custom="true" />
     </platform>
-
+    -->
 </plugin>


### PR DESCRIPTION
This plugin get merge into "windows" platform which is actually Universal Windows Platform. When submitting that Windows Phone appx file to store then submission failed because provided DLL isn't supported.

Error Message:
This API is not supported for this application type - Api=System.ComponentModel.DesignerProperties. Module=SYSTEM.WINDOWS, PUBLICKEYTOKEN=7CEC85D7BEA7798E. File=GoogleAds.dll.

Step to replicate this error.
1) Build "windows" plaform project
2) Run final appx file in "Windows App Cert Kit" (It will generate complete report)

FYI xap file generated by wp8 run fine on Windows Phone 8.1

Currently I'm using this commit to publish my app on windows store.

Similar issue:
https://github.com/floatinghotpot/cordova-admob-pro/issues/184