### PR TITLE
Adding showRewardVideoAd() arguments to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,7 +221,7 @@ isInterstitialReady(function(ready){ if(ready){ } });
 
 // use reward video
 prepareRewardVideoAd(adId/options, success, fail);
-showRewardVideoAd();
+showRewardVideoAd(successCallback, failureCallback);
 
 // set values for configuration and targeting
 setOptions(options, success, fail);


### PR DESCRIPTION
Currently it's impossible to know the arguments to showRewardVideoAd without looking at the code.