### PR TITLE
Introduce PLAY_SERVICES_VERSION

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -46,7 +46,8 @@
         <source-file src="src/android/AdMobPlugin.java" target-dir="src/com/rjfun/cordova/admob" />
 
         <!-- cordova CLI using gradle and it working well -->
-        <framework src="com.google.android.gms:play-services-ads:+" />
+	<preference name="PLAY_SERVICES_VERSION" default="+"/>
+        <framework src="com.google.android.gms:play-services-ads:$PLAY_SERVICES_VERSION" />
         <!-- but unfortunately, build.phonegap.com, Intel XDK, and some other tools still use ant -->
         <!-- dependency id="cordova-plugin-googleplayservices"/ -->
      </platform>


### PR DESCRIPTION
Hi @floatinghotpot this PR introduces a `PLAY_SERVICES_VERSION` variable in order to allow for specifying what version of `com.google.android.gms:play-services-ads` we want to use.

It could be use like this:

`cordova plugin add cordova-plugin-admobpro --variable PLAY_SERVICES_VERSION=11.0.8`

I'm one of your customers and I've been using your plugin for a while now. Unfortunately we are running into versioning issues when using cordova-admob-pro with other plugins. This change will help us a lot. I also just noticed another PR: https://github.com/floatinghotpot/cordova-admob-pro/pull/645 which I think asks for the same change.

Could you please merge this in? Thank you!