### PR TITLE
Allow setting of different app id for ios/android

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ Wanna quickly see the mobile ad on your simulator or device? Try the following c
 ```bash
 cordova plugin add cordova-plugin-admobpro
 
-cordova plugin add cordova-plugin-admobpro --save --variable PLAY_SERVICES_VERSION=16.0.0 --variable ADMOB_APP_ID="__your_admob_app_id___"
+cordova plugin add cordova-plugin-admobpro --save --variable PLAY_SERVICES_VERSION=16.0.0 --variable ADMOB_ANDROID_APP_ID="__your_admob_android_app_id___" --variable ADMOB_IOS_APP_ID="__your_admob_ios_app_id___"
 ```
 Or, if you see conflict when using Firebase, use this one instead:
 ```bash

--- a/plugin.xml
+++ b/plugin.xml
@@ -24,7 +24,8 @@
 
     <dependency id="cordova-plugin-extension" />
 
-    <preference name="ADMOB_APP_ID" default=""/>
+    <preference name="ADMOB_ANDROID_APP_ID" default=""/>
+    <preference name="ADMOB_IOS_APP_ID" default=""/>
     <preference name="PLAY_SERVICES_VERSION" default="16.0.0"/>
 
     <!-- android, now build with gradle instead of ant -->
@@ -43,7 +44,7 @@
                       android:theme="@android:style/Theme.Translucent" />
             <meta-data
                 android:name="com.google.android.gms.ads.APPLICATION_ID"
-                android:value="$ADMOB_APP_ID"/>
+                android:value="$ADMOB_ANDROID_APP_ID"/>
         </config-file>
         <config-file target="AndroidManifest.xml" parent="/*">
             <uses-permission android:name="android.permission.INTERNET"/>
@@ -99,7 +100,7 @@
         </config-file>
 
         <config-file target="*-Info.plist" parent="GADApplicationIdentifier">
-            <string>$ADMOB_APP_ID</string>
+            <string>$ADMOB_IOS_APP_ID</string>
         </config-file>
 
         <header-file src="src/ios/CDVAdMobPlugin.h"/>


### PR DESCRIPTION
# Problem

The new setting for `ADMOB_APP_ID` was taking a single variable that would be applied to both the android app's AndroidManifest.xml and the iOS apps plist config. Google issues different app ids for the android and ios version of an app, so it would seem appropriate to have two different settings.

# Solution

I split the variable definition of app id into two: one for android and one for ios. I also updated the readme.