### PR TITLE
Allows to send an user identifier to be used in Validating Server-Side Verification (SSV) Callbacks

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -241,6 +241,7 @@ AdMob.setOptions({
     job: "sailor",
     age: "23",
     interest: ["boats","ports"],
+	userId: "YOUR_USER_IDENTIFIER" // necessary if you plan to use some kind of server validation to reward-videos https://developers.google.com/admob/android/rewarded-video-ssv
   },
 });
 ```
@@ -379,6 +380,7 @@ Extra key/value for param **options**
 - **error**, *function*, call back when fail.
 
 > Note: it will take some time to get Ad resource before it can be showed. You may buffer the Ad by calling **prepareRewardVideoAd**, and show it later.
+> Note #2: if you plan to use some kind of server-side validation to reward your users, please use the setConfig method to provide identifier of the user seeing the video before prepare any video. Ref.: https://developers.google.com/admob/android/rewarded-video-ssv.
 
 ## AdMob.showRewardVideoAd() ##
 

--- a/src/android/AdMobPlugin.java
+++ b/src/android/AdMobPlugin.java
@@ -64,7 +64,8 @@ public class AdMobPlugin extends GenericAdPlugin {
   public static final String OPT_FORFAMILY = "forFamily";
   public static final String OPT_CONTENTURL = "contentUrl";
   public static final String OPT_CUSTOMTARGETING = "customTargeting";
-  public static final String OPT_EXCLUDE = "exclude";
+  public static final String OPT_EXCLUDE = "exclude";  
+  public static final String OPT_USER_ID = "userId";
 
   protected String mGender = null;
   protected String mForChild = null;
@@ -140,6 +141,9 @@ public class AdMobPlugin extends GenericAdPlugin {
     }
     if(options.has(OPT_EXCLUDE)) {
       mExclude = options.optJSONArray(OPT_EXCLUDE);
+    }    
+    if(options.has(OPT_USER_ID)) {
+      mUserId = options.optString(OPT_USER_ID);
     }
   }
 
@@ -309,6 +313,10 @@ protected void __showInterstitial(Object interstitial) {
 
     RewardedVideoAd ad = MobileAds.getRewardedVideoAdInstance(getActivity());
     ad.setRewardedVideoAdListener(new RewardVideoListener());
+
+    // if an useId is set, provide it to admob and it will be sent in server callback verification
+    if(mUserId != null)
+      ad.setUserId(mUserId);
 
     synchronized (mLock) {
       if (!mIsRewardedVideoLoading) {

--- a/src/ios/CDVAdMobPlugin.m
+++ b/src/ios/CDVAdMobPlugin.m
@@ -34,6 +34,7 @@
 #define OPT_CONTENTURL      @"contentURL"
 #define OPT_CUSTOMTARGETING @"customTargeting"
 #define OPT_EXCLUDE         @"exclude"
+#define OPT_USER_ID         @"userId"
 
 @interface CDVAdMobPlugin()<GADBannerViewDelegate, GADInterstitialDelegate, GADRewardBasedVideoAdDelegate>
 
@@ -122,6 +123,10 @@
     arr = [options objectForKey:OPT_EXCLUDE];
     if(arr != nil) {
         self.mExclude = arr;
+    }    
+    str = [options objectForKey:OPT_USER_ID];
+    if(str != nil){
+        self.mUserId = str;
     }
 }
 
@@ -339,6 +344,9 @@
 
 - (NSObject*) __prepareRewardVideoAd:(NSString*)adId {
     [GADRewardBasedVideoAd sharedInstance].delegate = self;
+    if (self.mUserId) {
+        [GADRewardBasedVideoAd sharedInstance].userIdentifier = self.mUserId;
+    }
     [[GADRewardBasedVideoAd sharedInstance] loadRequest:[GADRequest request]
                                            withAdUnitID:adId];
     return nil;


### PR DESCRIPTION
Hello,

This PR proposes a simple change in order to permit providing an user identifier before prepare any reward video in order to AdMob send this value when they call account callback Url. Admob suggests to use SSV callbacks to reward the users securely since they call a custom URL providing some details about the occurence when some user see a video. This way we can reward him/her trusting in a call from Admob rather just than trust in a call to API from JavaScript callback.

If you need some aditional information about SVV, you can find it here: https://developers.google.com/admob/android/rewarded-video-ssv.

I'm not a chinese speaker, so if you plan to accept this PR, please help me adding some content to README_CN.md file.

Regards,